### PR TITLE
Dynamic tasks & screen width bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,13 +49,22 @@ const render = (tasks, options) => {
 };
 
 class UpdateRenderer {
-	constructor(tasks, options) {
+	constructor(tasks, options, listr) {
 		this._tasks = tasks;
 		this._options = Object.assign({
 			showSubtasks: true,
 			collapse: true,
 			clearOutput: false
 		}, options);
+
+		// Older versions of Listr don't provide the listr instance
+		if (listr) {
+			listr.subscribe(event => {
+				if (event.type === 'ADDTASK') {
+					this._tasks.push(event.data);
+				}
+			});
+		}
 	}
 
 	render() {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ const renderHelper = (tasks, options, level) => {
 		if (task.isEnabled()) {
 			const skipped = task.isSkipped() ? ` ${chalk.dim('[skipped]')}` : '';
 
-			output.push(indentString(` ${utils.getSymbol(task, options)} ${task.title}${skipped}`, level, '  '));
+			const out = indentString(` ${utils.getSymbol(task, options)} ${task.title}${skipped}`, level, '  ');
+			output.push(cliTruncate(out, process.stdout.columns - 1));
 
 			if ((task.isPending() || task.isSkipped() || task.hasFailed()) && utils.isDefined(task.output)) {
 				let data = task.output;
@@ -31,7 +32,7 @@ const renderHelper = (tasks, options, level) => {
 
 				if (utils.isDefined(data)) {
 					const out = indentString(`${figures.arrowRight} ${data}`, level, '  ');
-					output.push(`   ${chalk.gray(cliTruncate(out, process.stdout.columns - 3))}`);
+					output.push(`   ${chalk.gray(cliTruncate(out, process.stdout.columns - 4))}`);
 				}
 			}
 

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
 	},
 	"devDependencies": {
 		"delay": "^1.3.1",
-		"listr": "^0.14.2",
+		"listr": "unboundedsystems/listr",
 		"xo": "^0.23.0",
 		"zen-observable": "^0.4.0"
 	},
 	"peerDependencies": {
-		"listr": "^0.14.2"
+		"listr": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "listr-update-renderer",
-	"version": "0.5.0",
+	"version": "0.5.0-unb1",
 	"description": "Listr update renderer",
 	"license": "MIT",
 	"repository": "SamVerschueren/listr-update-renderer",


### PR DESCRIPTION
This PR contains:

- Switch to Unbounded-specific versions until fixes are upstreamed
- Add support for adding tasks dynamically
- Fix for task titles and status wrapping beyond screen width